### PR TITLE
fix logging path

### DIFF
--- a/example/remotebenchmark/node1/main.go
+++ b/example/remotebenchmark/node1/main.go
@@ -88,14 +88,14 @@ func main() {
 	pid := actor.Spawn(props)
 
 	remotePid := actor.NewPID("127.0.0.1:8080", "remote")
-    if err := remotePid.
+	if err := remotePid.
 		RequestFuture(&messages.StartRemote{
 			Sender: pid,
 		}, 5*time.Second).
 		Wait(); err != nil {
-                fmt.Println("remote request failed:", err)
-                return
-        }
+		fmt.Println("remote request failed:", err)
+		return
+	}
 
 	wg.Add(1)
 

--- a/example/remotebenchmark/node1/main.go
+++ b/example/remotebenchmark/node1/main.go
@@ -88,11 +88,14 @@ func main() {
 	pid := actor.Spawn(props)
 
 	remotePid := actor.NewPID("127.0.0.1:8080", "remote")
-	remotePid.
+    if err := remotePid.
 		RequestFuture(&messages.StartRemote{
 			Sender: pid,
 		}, 5*time.Second).
-		Wait()
+		Wait(); err != nil {
+                fmt.Println("remote request failed:", err)
+                return
+        }
 
 	wg.Add(1)
 
@@ -110,8 +113,8 @@ func main() {
 
 	wg.Wait()
 	elapsed := time.Since(start)
-	fmt.Printf("Elapsed %s", elapsed)
+	fmt.Printf("Elapsed %s \n", elapsed)
 
 	x := int(float32(messageCount*2) / (float32(elapsed) / float32(time.Second)))
-	fmt.Printf("Msg per sec %v", x)
+	fmt.Printf("Msg per sec %v \n", x)
 }

--- a/log/string_encoder.go
+++ b/log/string_encoder.go
@@ -38,6 +38,7 @@ import (
 	"os"
 	"reflect"
 	"time"
+	"path"
 )
 
 type ioLogger struct {
@@ -57,13 +58,13 @@ func (l *ioLogger) listenEvent() {
 	}
 }
 
-func fileOpen(path string) (*os.File, error) {
-	if fi, err := os.Stat(path); err == nil {
+func fileOpen(logPath string) (*os.File, error) {
+	if fi, err := os.Stat(logPath); err == nil {
 		if !fi.IsDir() {
-			return nil, fmt.Errorf("open %s: not a directory", path)
+			return nil, fmt.Errorf("open %s: not a directory", logPath)
 		}
 	} else if os.IsNotExist(err) {
-		if err := os.MkdirAll(path, 0766); err != nil {
+		if err := os.MkdirAll(logPath, 0766); err != nil {
 			return nil, err
 		}
 	} else {
@@ -72,7 +73,7 @@ func fileOpen(path string) (*os.File, error) {
 
 	var currenttime string = time.Now().Format("2006-01-02_15.04.05")
 
-	logfile, err := os.OpenFile(path+currenttime+"_LOG.log", os.O_RDWR|os.O_CREATE, 0666)
+	logfile, err := os.OpenFile(path.Join(logPath, currenttime+"_LOG.log"), os.O_RDWR|os.O_CREATE, 0644)
 	if err != nil {
 		return nil, err
 	}

--- a/log/string_encoder.go
+++ b/log/string_encoder.go
@@ -36,9 +36,9 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path"
 	"reflect"
 	"time"
-	"path"
 )
 
 type ioLogger struct {
@@ -64,15 +64,14 @@ func fileOpen(logPath string) (*os.File, error) {
 			return nil, fmt.Errorf("open %s: not a directory", logPath)
 		}
 	} else if os.IsNotExist(err) {
-		if err := os.MkdirAll(logPath, 0766); err != nil {
+		if err := os.MkdirAll(logPath, 0755); err != nil {
 			return nil, err
 		}
 	} else {
 		return nil, err
 	}
 
-	var currenttime string = time.Now().Format("2006-01-02_15.04.05")
-
+	currenttime := time.Now().Format("2006-01-02_15.04.05")
 	logfile, err := os.OpenFile(path.Join(logPath, currenttime+"_LOG.log"), os.O_RDWR|os.O_CREATE, 0644)
 	if err != nil {
 		return nil, err

--- a/remote/endpoint_writer.go
+++ b/remote/endpoint_writer.go
@@ -92,7 +92,8 @@ func (state *endpointWriter) initializeInternal() error {
 	go func() {
 		_, err := stream.Recv()
 		if err != nil {
-			plog.Info("EndpointWriter lost connection to address", log.String("address", state.address))
+			plog.Info("EndpointWriter lost connection to address",
+				log.String("address", state.address), log.String("err", err.Error()))
 
 			//notify that the endpoint terminated
 			terminated := &EndpointTerminatedEvent{


### PR DESCRIPTION
1. if log path in LogInit() is not ended with '/', log file created with unexpected path.
2. fix remote example logging